### PR TITLE
Added support for Openshift monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Flags:
         Skip TLS Verfication (default false)
   -upstream string
         The upstream thanos URL (default "http://127.0.0.1:9090")
+  -bearer-file string
+        Path to file containing Authorization bearer token, if needed.
+  -force-get
+        Force prometheus api.Client to use GET requests instead of POST (default false)
 ```
 
 Sample k8s deployment (as a side car with thanos or prometheus):

--- a/client.go
+++ b/client.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+// ClientConfigError returned when the token file is empty or invalid
+type ClientConfigError string
+
+// Error implements error
+func (err ClientConfigError) Error() string {
+	return string(err)
+}
+
+const (
+	EmptyBearerFileError    = ClientConfigError("First line of bearer token file is empty")
+	InvalidBearerTokenError = ClientConfigError("Bearer token must be ASCII")
+	NilOptionError          = ClientConfigError("configOption cannot be nil")
+)
+
+// Client wraps prometheus api.Client to add custom headers to every request
+type client struct {
+	api.Client
+	authz string // Authorization header
+	asGet bool   // True to reject POST requests
+}
+
+type paramKey int
+
+// addValues inserts the provided request params in context
+func addValues(ctx context.Context, params url.Values) context.Context {
+	return context.WithValue(ctx, paramKey(0), params)
+}
+
+// getValues extracts from context the params provided by addParams
+func getValues(ctx context.Context) (url.Values, bool) {
+	if ctxValue := ctx.Value(paramKey(0)); ctxValue != nil {
+		if params, ok := ctxValue.(url.Values); ok {
+			return params, true
+		}
+	}
+	return nil, false
+}
+
+// Do implements api.Client
+func (c client) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	if c.asGet && req.Method == http.MethodPost {
+		// If response to POST is http.StatusMethodNotAllowed,
+		// Prometheus api library will failover to GET.
+		return &http.Response{
+			Status:        "Method Not Allowed",
+			StatusCode:    http.StatusMethodNotAllowed,
+			Proto:         req.Proto,
+			ProtoMajor:    req.ProtoMajor,
+			ProtoMinor:    req.ProtoMinor,
+			Body:          ioutil.NopCloser(nil),
+			ContentLength: 0,
+			Request:       req,
+			Header:        make(http.Header, 0),
+		}, nil, nil
+	}
+	// If context includes URL parameters, append them to the query
+	if params, ok := getValues(ctx); ok {
+		reqParams := req.URL.Query()
+		for name, values := range params {
+			for _, value := range values {
+				reqParams.Add(name, value)
+			}
+		}
+		req.URL.RawQuery = reqParams.Encode()
+	}
+	if c.authz != "" {
+		if req.Header == nil {
+			req.Header = make(http.Header)
+		}
+		req.Header.Set("Authorization", c.authz)
+	}
+	return c.Client.Do(ctx, req)
+}
+
+// readBearerToken from given FS and fileName.
+// Takes sys.FS instead of path for easier testing.
+func readBearerToken(fsys fs.FS, fileName string) (string, error) {
+	bearerFile, err := fsys.Open(fileName)
+	if err != nil {
+		return "", err
+	}
+	defer bearerFile.Close()
+	scanner := bufio.NewScanner(bearerFile)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return "", err
+		}
+		return "", EmptyBearerFileError
+	}
+	return scanner.Text(), nil
+}
+
+// IsAscii checks if string consists only of ascii characters
+func isAscii(str string) bool {
+	for _, b := range str {
+		if b <= 0 || b > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+// clientOption implements functional options pattern for client
+type clientOption func(c *client) error
+
+// newClient wraps an api.Client adding the given options
+func newClient(c api.Client, opts ...clientOption) (client, error) {
+	result := client{Client: c}
+	if len(opts) > 0 {
+		for _, opt := range opts {
+			// catch wrong calls to newClient(c, nil)
+			if opt == nil {
+				return client{}, NilOptionError
+			}
+			if err := opt(&result); err != nil {
+				return client{}, err
+			}
+		}
+	}
+	return result, nil
+}
+
+// withToken adds Authz bearer token to all requests
+func withToken(bearer string) clientOption {
+	return func(c *client) error {
+		bearer = strings.TrimSpace(bearer)
+		if bearer == "" || !isAscii(bearer) {
+			return InvalidBearerTokenError
+		}
+		c.authz = fmt.Sprintf("Bearer %s", bearer)
+		return nil
+	}
+}
+
+// withGet only allows GET queries
+func withGet(c *client) error {
+	c.asGet = true
+	return nil
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"testing/fstest"
+
+	"github.com/prometheus/client_golang/api"
+)
+
+const (
+	validBearerToken  = "Any Regular ASCII string"
+	validBearerHeader = "Bearer " + validBearerToken
+)
+
+// mockClient does a poor job at mocking prometheus api.Client
+type mockClient struct {
+	header http.Header
+	reqURL *url.URL
+}
+
+// URL implements api.Client
+func (m *mockClient) URL(ep string, args map[string]string) *url.URL {
+	return nil
+}
+
+// Do implements api.Client
+func (m *mockClient) Do(ctx context.Context, req *http.Request) (*http.Response, []byte, error) {
+	m.header = req.Header
+	m.reqURL = req.URL
+	return nil, nil, nil
+}
+
+// TestBearerToken validates bearer token reading and insertion
+func TestBearerToken(t *testing.T) {
+
+	fsys := fstest.MapFS{
+		"empty_bearer": {
+			Data: []byte{},
+		},
+		"empty_first_line_bearer": {
+			Data: []byte("\nFirst line cannot be emtpy"),
+		},
+		"invalid_bearer": {
+			Data: []byte("bearer must be ascii: áéíóú"),
+		},
+		"valid_bearer": {
+			Data: []byte(validBearerToken),
+		},
+		"valid_bearer_with_whitespace": {
+			Data: []byte("   " + validBearerToken + "  "),
+		},
+	}
+
+	read := func(fileName string) (*mockClient, api.Client, error) {
+		m := &mockClient{}
+		b, err := readBearerToken(fsys, fileName)
+		if err != nil {
+			return m, nil, err
+		}
+		c, err := newClient(m, withToken(b))
+		return m, c, err
+	}
+
+	// Check invalid files raise proper errors
+	invalid := map[string]error{
+		"empty_bearer":            EmptyBearerFileError,
+		"empty_first_line_bearer": InvalidBearerTokenError,
+		"invalid_bearer":          InvalidBearerTokenError,
+	}
+	for fileName, expectedErr := range invalid {
+		t.Run("Read bearer from "+fileName, func(t *testing.T) {
+			_, _, err := read(fileName)
+			if !errors.Is(err, expectedErr) {
+				t.Fatal(fmt.Sprintf("Expected error %v, got %v", expectedErr, err))
+			}
+		})
+	}
+
+	// Check valid files send proper token
+	valid := []string{
+		"valid_bearer",
+		"valid_bearer_with_whitespace",
+	}
+	for _, fileName := range valid {
+		t.Run("Read bearer from "+fileName, func(t *testing.T) {
+			m, c, err := read(fileName)
+			if err != nil {
+				t.Fatal(fmt.Sprintf("Expected no error, got %v", err))
+			}
+			req, _ := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+			c.Do(context.TODO(), req)
+			if m.header == nil || len(m.header) <= 0 {
+				t.Fatal("Empty headers in request")
+			}
+			if authz := m.header.Get("Authorization"); authz != validBearerHeader {
+				t.Fatal(fmt.Sprintf("Expected Authorization header '%s', got '%s'", validBearerHeader, authz))
+			}
+		})
+	}
+}
+
+// TestWithGet validates GET request filtering
+func TestWithGet(t *testing.T) {
+
+	post := func(t *testing.T, opts ...clientOption) *http.Response {
+		c, err := newClient(&mockClient{}, opts...)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		req, _ := http.NewRequest(http.MethodPost, "http://localhost/test", io.NopCloser(bytes.NewReader([]byte{})))
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		res, _, err := c.Do(context.TODO(), req)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		return res
+	}
+
+	t.Run("regular client permits POST", func(t *testing.T) {
+		if res := post(t); res != nil {
+			t.Fatalf("Expected nil response (from mock), got %v", res)
+		}
+	})
+
+	t.Run("withGet client rejects POST", func(t *testing.T) {
+		res := post(t, withGet)
+		if res == nil {
+			t.Fatal("Expected not-nil response")
+		}
+		if res.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("Expected status code %d, got %v", http.StatusMethodNotAllowed, res)
+		}
+	})
+}
+
+// TestWithValues validates params passing through context
+func TestWithValues(t *testing.T) {
+	m := mockClient{}
+	c, err := newClient(&m)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	v, _ := url.ParseQuery("key1=val1&key2=val2")
+	ctx := addValues(context.TODO(), v)
+	req, _ := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+	if _, _, err := c.Do(ctx, req); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	urlQuery := m.reqURL.Query()
+	if !reflect.DeepEqual(v, urlQuery) {
+		t.Fatalf("Expected query parameters %v, got %v", v, urlQuery)
+	}
+}
+
+// TestNilOption makes sure config doesn't panic if a nil option is passed
+func TestNilOption(t *testing.T) {
+	if _, err := newClient(&mockClient{}, nil); !errors.Is(err, NilOptionError) {
+		t.Fatalf("Expected error %v, got %v", NilOptionError, err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -79,10 +79,8 @@ func main() {
 		klog.Infof("Forcing api,Client to use GET requests")
 		options = append(options, withGet)
 	}
-	if len(options) > 0 {
-		if c, err = newClient(c, options...); err != nil {
-			klog.Fatalf("error building custom API client:", err)
-		}
+	if c, err = newClient(c, options...); err != nil {
+		klog.Fatalf("error building custom API client:", err)
 	}
 	apiClient := v1.NewAPI(c)
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -21,12 +23,16 @@ var (
 	insecureListenAddress string
 	upstream              string
 	tlsSkipVerify         bool
+	bearerFile            string
+	forceGet              bool
 )
 
 func parseFlag() {
 	flag.StringVar(&insecureListenAddress, "insecure-listen-address", "127.0.0.1:9099", "The address which proxy listens on")
 	flag.StringVar(&upstream, "upstream", "http://127.0.0.1:9090", "The upstream thanos URL")
-	flag.BoolVar(&tlsSkipVerify, "tlsSkipVerify", false, "Skip TLS Verfication")
+	flag.BoolVar(&tlsSkipVerify, "tlsSkipVerify", false, "Skip TLS Verification")
+	flag.StringVar(&bearerFile, "bearer-file", "", "File containing bearer token for API requests")
+	flag.BoolVar(&forceGet, "force-get", false, "Force api.Client to use GET by rejecting POST requests")
 	flag.Parse()
 }
 
@@ -55,6 +61,29 @@ func main() {
 	if err != nil {
 		klog.Fatalf("error creating API client:", err)
 	}
+	// Collect client options
+	options := []clientOption{}
+	if bearerFile != "" {
+		fullPath, err := filepath.Abs(bearerFile)
+		if err != nil {
+			klog.Fatalf("error locating bearer file:", err)
+		}
+		dirName, fileName := filepath.Split(fullPath)
+		bearer, err := readBearerToken(os.DirFS(dirName), fileName)
+		if err != nil {
+			klog.Fatalf("error reading bearer file:", err)
+		}
+		options = append(options, withToken(bearer))
+	}
+	if forceGet {
+		klog.Infof("Forcing api,Client to use GET requests")
+		options = append(options, withGet)
+	}
+	if len(options) > 0 {
+		if c, err = newClient(c, options...); err != nil {
+			klog.Fatalf("error building custom API client:", err)
+		}
+	}
 	apiClient := v1.NewAPI(c)
 
 	// server mux
@@ -72,9 +101,13 @@ func main() {
 func federate(ctx context.Context, w http.ResponseWriter, r *http.Request, apiClient v1.API) {
 	// TODO: extend to support multiple match queries
 	// This will only act based on first match query
-	matchQuery := r.URL.Query().Get("match[]")
+	params := r.URL.Query()
+	matchQuery := params.Get("match[]")
 
 	nctx, ncancel := context.WithTimeout(r.Context(), 2*time.Minute)
+	if params.Del("match[]"); len(params) > 0 {
+		nctx = addValues(nctx, params)
+	}
 	start := time.Now()
 	val, _, err := apiClient.Query(nctx, matchQuery, time.Now()) // Ignoring warnings for now.
 	responseTime := time.Since(start).Seconds()


### PR DESCRIPTION
First of all, thanks for sharing this software!

I'm trying to use this proxy to federate my Prometheus to the Thanos querier in an Openshift cluster. But the built-in Thanos querier in Openshift is "hidden" behind a reverse proxy, to provide some multitenant capabilities (please see https://cloud.redhat.com/blog/thanos-querier-versus-thanos-querier for details), and has many gotchas:

1. search requests must include a `namespace` URL parameter.
2. search requests must include an `Authorization` HTTP header with the customer's ServiceAccount token.
3. Only GET is supported. POSTs are forbidden with a 403 Unauthorized. The `prometheus/golang-client` library automatically switches from POST to GET if the status code is 405 (Method not allowed) or 501 (Not Implemented), but not on 403.

I'm using a forked version of this repo to scrape the metrics from my Openshift thanos instance. It required two new command line flags:

- `-token-file <path_to_token_file>`: reads a token from a file and adds it in the `Authorization` header of every request to Thanos.
- `-force-get`: intercepts all POST request that the `prometheus/golang-client` library tries to send, and blocks them with a `405 Method not allowed` to force a retry with GET.

I'm submitting this as a PR in case someone else finds these flags useful, outside of Openshift.